### PR TITLE
Enable sparse file support on macOS

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1062,19 +1062,34 @@ fn find_sparse_entries(
     file: &mut fs::File,
     stat: &fs::Metadata,
 ) -> io::Result<Option<SparseEntries>> {
-    #[cfg(not(any(target_os = "android", target_os = "freebsd", target_os = "linux")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos"
+    )))]
     {
         let _ = file;
         let _ = stat;
         Ok(None)
     }
 
-    #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos"
+    ))]
     find_sparse_entries_seek(file, stat)
 }
 
 /// Implementation of `find_sparse_entries` using `SEEK_HOLE` and `SEEK_DATA`.
-#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "macos"
+))]
 fn find_sparse_entries_seek(
     file: &mut fs::File,
     stat: &fs::Metadata,

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1489,6 +1489,8 @@ fn writing_sparse() {
     assert!(data.len() <= 37 * 1024); // ext4 (defaults to 4k block size)
     #[cfg(target_os = "freebsd")]
     assert!(data.len() <= 273 * 1024); // UFS (defaults to 32k block size, last block isn't a hole)
+    #[cfg(target_os = "macos")]
+    assert!(data.len() <= 37 * 1024); // APFS (4k block size)
 
     let mut ar = Archive::new(&data[..]);
     let mut entries = ar.entries().unwrap();


### PR DESCRIPTION
Sparse file detection in Builder is cfg-gated to Linux, Android, and FreeBSD, so macOS silently falls back to dense copies. The existing implementation already works on macOS unchanged: the non-Linux path probes fpathconf(_PC_MIN_HOLE_SIZE) before using SEEK_HOLE/SEEK_DATA, and APFS supports all three (libc exposes the constants for apple targets).

This PR adds target_os = "macos" to the three cfg gates in src/builder.rs and enables the writing_sparse size assertion on macOS.

I found this while debugging snapshot write amplification in qdrant (qdrant/qdrant#9858). Archiving a 32 MiB hole-backed file with 4 KiB of data via append_path_with_name:

- Linux (ext4): 9,728 byte archive, GNU sparse entry
- macOS (APFS), before: 33,555,968 bytes, dense regular entry
- macOS (APFS), after this change: 34,304 bytes, GNU sparse entry, extracted contents byte-identical

Same code, same file, the gate was the only difference.

Verified on macOS 15 (arm64, APFS): full test suite passes including all 5 sparse tests, and writing_sparse measures 37,888 bytes, the same 4k-block bound as ext4, so the assertion reuses the 37 KiB limit.