### PR TITLE
fix(builder): set size to 0 and default entry type in append_link

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -268,9 +268,9 @@ impl<W: Write> Builder<W> {
     ///
     /// This function is similar to [`Self::append_data`] which supports long filenames,
     /// but also supports long link targets using GNU extensions if necessary.
-    /// You must set the entry type to either [`EntryType::Link`] or [`EntryType::Symlink`].
-    /// The `set_cksum` method will be invoked after setting the path. No other metadata in the
-    /// header will be modified.
+    /// If the entry type is not already set to [`EntryType::Link`] or [`EntryType::Symlink`],
+    /// it will default to [`EntryType::Symlink`]. The header size will automatically be set to 0.
+    /// The `set_cksum` method will be invoked after setting the path.
     ///
     /// If you are intending to use GNU extensions, you must use this method over calling
     /// [`Header::set_link_name`] because that function will fail on long links.
@@ -291,8 +291,6 @@ impl<W: Write> Builder<W> {
     /// let mut ar = Builder::new(Vec::new());
     /// let mut header = Header::new_gnu();
     /// header.set_username("foo");
-    /// header.set_entry_type(EntryType::Symlink);
-    /// header.set_size(0);
     /// ar.append_link(&mut header, "really/long/path/to/foo", "other/really/long/target").unwrap();
     /// let data = ar.into_inner().unwrap();
     /// ```
@@ -309,6 +307,10 @@ impl<W: Write> Builder<W> {
         let allow_abolute = self.options.preserve_absolute;
         prepare_header_path(self.get_mut(), header, path, allow_abolute)?;
         prepare_header_link(self.get_mut(), header, target)?;
+        if !header.entry_type().is_hard_link() && !header.entry_type().is_symlink() {
+            header.set_entry_type(EntryType::Symlink);
+        }
+        header.set_size(0);
         header.set_cksum();
         self.append(header, std::io::empty())
     }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -2168,3 +2168,22 @@ async fn pax_extension_header_matches_astral_tokio_tar() {
         "astral-tokio-tar produced unexpected entries\ngot: {async_entries:?}"
     );
 }
+
+#[test]
+fn append_link_defaults_size_and_type() {
+    let mut ar = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    ar.append_link(&mut header, "my/link", "target/path")
+        .unwrap();
+    let data = ar.into_inner().unwrap();
+
+    let mut archive = Archive::new(data.as_slice());
+    let mut entries = archive.entries().unwrap();
+    let entry = entries.next().unwrap().unwrap();
+    assert_eq!(entry.header().size().unwrap(), 0);
+    assert!(entry.header().entry_type().is_symlink());
+    assert_eq!(
+        entry.link_name().unwrap().unwrap().to_str(),
+        Some("target/path")
+    );
+}


### PR DESCRIPTION
## Problem
When using `Builder::append_link()`, if callers did not manually set `header.set_size(0)`, any non-zero size remaining in the header resulted in TAR readers expecting file payload bytes following the link header, leading to corrupted archives and reader errors. Additionally, callers had to manually specify `header.set_entry_type(EntryType::Symlink)`.

## Solution
1. In `Builder::_append_link()`, automatically set `header.set_size(0)`.
2. If `header.entry_type()` is not already a link type (`Link` or `Symlink`), default it to `EntryType::Symlink`.
3. Updated doc comments and example in `src/builder.rs`.
4. Added test `append_link_defaults_size_and_type` in `tests/all.rs`.

## Verification
- Executed `cargo test`, all 74 unit tests and 14 doc-tests pass.

Fixes #311
