### PR TITLE
fix(header): allow blank/whitespace octal fields to parse as zero

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1483,7 +1483,11 @@ fn octal_from(slice: &[u8]) -> io::Result<u64> {
             )));
         }
     };
-    match u64::from_str_radix(num.trim(), 8) {
+    let trimmed = num.trim();
+    if trimmed.is_empty() {
+        return Ok(0);
+    }
+    match u64::from_str_radix(trimmed, 8) {
         Ok(n) => Ok(n),
         Err(_) => Err(other(&format!("numeric field was not a number: {}", num))),
     }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -2168,3 +2168,30 @@ async fn pax_extension_header_matches_astral_tokio_tar() {
         "astral-tokio-tar produced unexpected entries\ngot: {async_entries:?}"
     );
 }
+
+#[test]
+fn gnu_volume_header_label_iteration() {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu();
+    header.set_entry_type(tar::EntryType::new(b'V'));
+    header.as_old_mut().size = [b' '; 12];
+    header.set_path("MY_TAR_LABEL").unwrap();
+    header.set_cksum();
+    builder.append(&header, std::io::empty()).unwrap();
+
+    let mut file_header = Header::new_gnu();
+    file_header.set_path("a.txt").unwrap();
+    file_header.set_size(2);
+    file_header.set_cksum();
+    builder.append(&file_header, b"A\n".as_slice()).unwrap();
+
+    let data = builder.into_inner().unwrap();
+    let mut ar = Archive::new(data.as_slice());
+    let paths: Vec<String> = ar
+        .entries()
+        .unwrap()
+        .map(|e| e.unwrap().path().unwrap().to_str().unwrap().to_owned())
+        .collect();
+
+    assert_eq!(paths, vec!["MY_TAR_LABEL", "a.txt"]);
+}

--- a/tests/header/mod.rs
+++ b/tests/header/mod.rs
@@ -261,3 +261,13 @@ fn byte_slice_conversion() {
     let b_conv: &[u8] = Header::from_byte_slice(h.as_bytes()).as_bytes();
     assert_eq!(b, b_conv);
 }
+
+#[test]
+fn blank_octal_field_parses_as_zero() {
+    let mut h = Header::new_gnu();
+    h.as_old_mut().size = [b' '; 12];
+    assert_eq!(h.entry_size().unwrap(), 0);
+
+    h.as_old_mut().size = [0; 12];
+    assert_eq!(h.entry_size().unwrap(), 0);
+}


### PR DESCRIPTION
## Problem
When reading tar archives containing GNU volume labels (created with `tar --label ...`) or other headers where numeric octal fields (such as size) contain only spaces or null bytes, `octal_from()` previously passed an empty trimmed string `""` to `u64::from_str_radix()`, resulting in error `"numeric field was not a number: "`. This prevented iterating entries with `Archive::entries()`.

## Solution
1. In `octal_from()` (`src/header.rs`), return `Ok(0)` when the trimmed string is empty.
2. Added unit test `blank_octal_field_parses_as_zero` in `tests/header/mod.rs`.
3. Added integration test `gnu_volume_header_label_iteration` in `tests/all.rs` verifying that archives containing volume labels iterate all entries without error.

## Verification
- Ran `cargo test`, all 75 unit/integration tests and 14 doc-tests pass.

Fixes #440
